### PR TITLE
Add ability to trim suffix

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -17,6 +17,7 @@ route /assets/* {
 			region "us-east-1"
 			endpoint "http://localhost:9000"
 			force_path_style
+			trim_path_suffix
 		}
 		pass_thru
 	}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ file_server {
 		# endpoint <endpoint>
 		# profile <profile>
 		# force_path_style
+		# trim_path_suffix
 	}
 }
 ```


### PR DESCRIPTION
As discussed at https://github.com/sagikazarmark/caddy-fs-s3/issues/26, Caddy is tacking on a `/` which causes ValidPath in s3fs to throw an error. This PR implements the `Stat` and `Open` functions and simply strips the `/` off of the filename and passes it along to s3fs.

Not the most elegant, and the issue can be solved in other ways (as noted in the linked issue), but I thought I'd share a potential solution. No worries if you don't want to merge :) 