### PR TITLE
Update readme in preparation for next caddy release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ xcaddy --with github.com/sagikazarmark/caddy-fs-s3
 ## Usage
 
 ```caddyfile
+example.com
+
+file_server {
+	fs s3 {
+		bucket mybucket
+		region us-east-1
+
+		# endpoint <endpoint>
+		# profile <profile>
+		# use_path_style
+	}
+}
+```
+
+## Usage with Caddy master/2.8.0+
+
+```caddyfile
 {
 	filesystem my-s3-fs s3 {
 		bucket mybucket
@@ -32,7 +49,6 @@ example.com {
     }
 }
 ```
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ xcaddy --with github.com/sagikazarmark/caddy-fs-s3
 ## Usage
 
 ```caddyfile
-example.com
-
-file_server {
-	fs s3 {
+{
+	filesystem my-s3-fs s3 {
 		bucket mybucket
 		region us-east-1
 
@@ -26,6 +24,12 @@ file_server {
 		# profile <profile>
 		# use_path_style
 	}
+}
+
+example.com {
+    file_server {
+        fs my-s3-fs
+    }
 }
 ```
 


### PR DESCRIPTION
In future versions of caddy, filesystems have been changed to be declared in the global block, then referenced using the fs directive, see https://github.com/caddyserver/caddy/pull/5833

this is a breaking change, see #288 

it shouldn't break the actual plugin (if it does, let me know, and i can investigate), but the readme should be updated. 

also probably shouldn't merge until the next official caddy release.