### PR TITLE
suppress S3 SDK checksum warning

### DIFF
--- a/module.go
+++ b/module.go
@@ -87,7 +87,7 @@ func (fs *FS) Provision(ctx caddy.Context) error {
 		if fs.Endpoint != "" {
 			o.BaseEndpoint = aws.String(fs.Endpoint)
 		}
-
+		o.DisableLogOutputChecksumValidationSkipped = true
 		o.UsePathStyle = fs.UsePathStyle || fs.S3ForcePathStyle
 	})
 


### PR DESCRIPTION
the new AWS SDK floods the log with a checksum warning.

This happens when using S3 sources different from AWS S3. 

This PR suppresses this warning


```
Jun  3 16:58:19 caddy[393404]: message repeated 33 times: [ SDK 2025/06/03 16:58:19 WARN Response has no supported checksum. Not validating response payload.]
Jun  3 16:58:20 caddy[393404]: SDK 2025/06/03 16:58:20 WARN Response has no supported checksum. Not validating response payload.
```

Here's a blog post I found about the issue: https://tsak.dev/posts/aws-sdk-suppress-checksum-warning/